### PR TITLE
upgrade peco to 0.4.7

### DIFF
--- a/peco.nuspec
+++ b/peco.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>peco</id>
     <title>peco</title>
-    <version>0.3.6</version>
+    <version>0.4.7</version>
     <authors>lestrrat</authors>
     <owners>taichi</owners>
     <summary>Simplistic interactive filtering tool</summary>

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,5 +1,5 @@
 $packageName = "peco"
-$version = "0.3.6"
+$version = "0.4.7"
 $url = "https://github.com/peco/peco/releases/download/v$version/peco_windows_386.zip"
 $url64 = "https://github.com/peco/peco/releases/download/v$version/peco_windows_amd64.zip"
 


### PR DESCRIPTION
The version in chocolatey is a little outdated. There are some new features (like the Fuzzy filter) in newer version. Here's a PR with the latest version (0.4.7).